### PR TITLE
Add 12 new portfolio projects and 3 new case studies

### DIFF
--- a/src/app/case-studies/page.jsx
+++ b/src/app/case-studies/page.jsx
@@ -95,6 +95,72 @@ const caseStudies = [
     duration: "16 weeks",
     teamSize: "4 engineers",
   },
+  {
+    id: "theloadoff",
+    tag: "Operations · SaaS · US Client",
+    client: "US-based Service Provider",
+    title: "Five disconnected tools replaced by one unified operations platform",
+    summary:
+      "A US-based service provider was managing customer requests, task assignments, team communication, time tracking, and billing across five separate tools. Admins had no single view of business operations, leading to missed tasks, delayed invoices, and fragmented client communication.",
+    challenge:
+      "Build a unified platform with clear role separation for admins, service managers, and clients — covering the full service lifecycle from request intake through task execution to invoice generation, without any tool-switching.",
+    solution:
+      "We designed and built a custom operations platform with six tightly integrated modules: client management with request intake, task management with priority and due-date tracking, time logging per task, task-based messaging with a centralized inbox, automated invoice generation from logged hours, and a reporting dashboard covering workload, overdue tasks, and team performance.",
+    results: [
+      { metric: "5 → 1", label: "Tools replaced by one platform" },
+      { metric: "100%", label: "Visibility on all active service requests" },
+      { metric: "3 roles", label: "Admin, Manager, Client — fully separated" },
+      { metric: "Auto", label: "Invoice generation from tracked time" },
+    ],
+    stack: ["React", "Node.js", "PostgreSQL", "Stripe", "AWS", "Socket.io"],
+    image: "/images/portfolio-glovebox.png",
+    duration: "12 weeks",
+    teamSize: "3 engineers",
+  },
+  {
+    id: "darren",
+    tag: "Logistics · SaaS · Multi-role Platform",
+    client: "Logistics Startup",
+    title: "From MVP to commercial SaaS — a logistics platform built to scale",
+    summary:
+      "A logistics startup needed a platform that could connect cargo owners with verified fleet operators and drivers for transparent, end-to-end freight coordination. The existing process relied on phone calls, WhatsApp groups, and manual paperwork — with no accountability or visibility.",
+    challenge:
+      "Build a multi-role logistics ecosystem where cargo owners post jobs, fleet owners bid and assign drivers, and drivers manage pickups, deliveries, and proof-of-delivery uploads — with a super admin layer governing the entire platform.",
+    solution:
+      "We shipped an MVP in Phase 1 covering cargo job posting, bidding workflows, vehicle and driver assignment, basic document handling, and POD uploads. After gathering real user feedback from cargo companies and fleet operators, we evolved the platform into a commercial SaaS in Phase 2 — adding live GPS-based tracking, structured bid revision support, driver verification and vehicle compliance checks, cancellation workflows with full audit trail, and a super admin dashboard with complete operational visibility.",
+    results: [
+      { metric: "2-phase", label: "MVP to commercial SaaS delivery" },
+      { metric: "5 roles", label: "Super Admin, Admin, Cargo Owner, Fleet Owner, Driver" },
+      { metric: "Live GPS", label: "Real-time route tracking per shipment" },
+      { metric: "100%", label: "Timestamped audit trail on all actions" },
+    ],
+    stack: ["React.js", "Node.js", "MongoDB", "Google Maps API", "SendGrid", "FCM", "TailwindCSS"],
+    image: "/images/portfolio-readybuild.png",
+    duration: "16 weeks (MVP + Phase 2)",
+    teamSize: "4 engineers",
+  },
+  {
+    id: "eurotile",
+    tag: "B2B Marketplace · E-Commerce · Multi-vendor",
+    client: "European Tile Manufacturer",
+    title: "Two platforms, one product line — B2B marketplace and B2C storefront for a tile business",
+    summary:
+      "A European tile manufacturer needed two distinct platforms: a B2B marketplace to connect manufacturers, distributors, and retailers for bulk trade, and a separate B2C storefront for direct retail sales to consumers and interior designers.",
+    challenge:
+      "The B2B platform required tiered pricing by square footage, multi-vendor ordering, supplier approval workflows, sample ordering before bulk commitment, and dynamic order windows aligned to supply cycles. The B2C platform needed to be simpler — clean catalog, real-time inventory, and a smooth checkout — but fully admin-controlled.",
+    solution:
+      "We built EuroTile Pro (B2B) with vendor and buyer approval flows, tiered volume pricing, a multi-vendor cart with structured checkout, sample and demo ordering, and shipping reference tracking since fulfillment is handled off-platform. In parallel, we built EuroTile B2C as a retail-focused storefront with attribute-based filtering, sample ordering, real-time inventory visibility, and a centralized admin backend for managing products, pricing, and orders.",
+    results: [
+      { metric: "2", label: "Platforms built (B2B + B2C) in parallel" },
+      { metric: "Tiered", label: "Pricing by order volume in sq ft" },
+      { metric: "Real-time", label: "Inventory visibility across both platforms" },
+      { metric: "Sample", label: "Ordering workflow before full purchase" },
+    ],
+    stack: ["React", "Node.js", "PostgreSQL", "Stripe", "AWS", "REST APIs"],
+    image: "/images/portfolio-dnh.png",
+    duration: "14 weeks",
+    teamSize: "3 engineers",
+  },
 ];
 
 export default function CaseStudiesPage() {
@@ -117,7 +183,8 @@ export default function CaseStudiesPage() {
             </h1>
             <p className="text-xl text-slate-500 leading-relaxed">
               We don&apos;t do vague case studies. Here are the actual problems our clients
-              faced, what we built, and what changed after launch.
+              faced, what we built, and what changed — across insurance, construction,
+              logistics, operations, e-commerce, and more.
             </p>
           </div>
         </div>

--- a/src/app/portfolio/page.jsx
+++ b/src/app/portfolio/page.jsx
@@ -1,12 +1,13 @@
 "use client";
 
+import { useState } from "react";
 import { motion } from "framer-motion";
 import Image from "next/image";
 import Navbar from "../components/navbar";
 import Footer from "../components/footer";
 import CTABanner from "../components/cta-banner";
 
-const projects = [
+const featured = [
   {
     title: "GloveBox CRM",
     description:
@@ -41,7 +42,127 @@ const projects = [
   },
 ];
 
+const moreProjects = [
+  {
+    title: "The Load Off",
+    description:
+      "Unified operations platform replacing 5 disconnected tools for a US service provider — covering client management, task tracking, time logging, messaging, and billing in one place.",
+    link: "https://www.theloadoff.com/",
+    tags: ["Operations", "SaaS", "US Client"],
+    category: "SaaS / Enterprise",
+    gradient: "from-teal-600 to-cyan-500",
+  },
+  {
+    title: "Darren – Logistics Platform",
+    description:
+      "Multi-role logistics coordination system connecting cargo owners, fleet operators, and drivers with structured bidding, GPS tracking, proof of delivery, and a full audit trail.",
+    link: null,
+    tags: ["Logistics", "Multi-role", "React"],
+    category: "Logistics & Operations",
+    gradient: "from-blue-600 to-indigo-500",
+  },
+  {
+    title: "SheWatches",
+    description:
+      "Live video interaction platform for a US-based client — real-time peer matching, intelligent pairing algorithms, built-in moderation, and scalable concurrent video session handling.",
+    link: "https://shewatches.com/",
+    tags: ["Video Streaming", "Real-time", "WebRTC"],
+    category: "SaaS / Enterprise",
+    gradient: "from-violet-600 to-purple-500",
+  },
+  {
+    title: "EuroTile Pro – B2B Marketplace",
+    description:
+      "B2B tile marketplace connecting manufacturers, distributors, and retailers with tiered pricing by square footage, multi-vendor ordering, sample management, and supplier approval workflows.",
+    link: "https://eurotile.pro/",
+    tags: ["B2B Marketplace", "Tile Industry", "Multi-vendor"],
+    category: "Marketplace",
+    gradient: "from-orange-500 to-amber-500",
+  },
+  {
+    title: "EuroTile – B2C Storefront",
+    description:
+      "Retail e-commerce platform for a European tile business with catalog browsing, attribute filters, sample ordering, real-time inventory, and a centralized admin backend.",
+    link: "https://eurotile.com/",
+    tags: ["E-Commerce", "Retail", "Node.js"],
+    category: "E-Commerce",
+    gradient: "from-amber-500 to-yellow-500",
+  },
+  {
+    title: "FairBnb – Booking Engine",
+    description:
+      "Advanced booking platform for service-based businesses with real-time availability, appointment scheduling, secure payments, automated reminders, and a post-service reviews system.",
+    link: "https://fairbnb.coop/",
+    tags: ["Booking", "Marketplace", "SaaS"],
+    category: "Marketplace",
+    gradient: "from-emerald-600 to-teal-500",
+  },
+  {
+    title: "PurveyPro",
+    description:
+      "SaaS loan management platform where professionals act as middlemen for borrowers — supporting personalized invite links, multiple lending options, and business funding plan generation.",
+    link: "https://purveypro.com",
+    tags: ["FinTech", "Loan Management", "SaaS"],
+    category: "FinTech",
+    gradient: "from-green-600 to-emerald-500",
+  },
+  {
+    title: "Meals on Wheels 4U",
+    description:
+      "Food ordering and delivery platform with menu browsing, recurring delivery scheduling, real-time tracking, and an optional AI voice ordering integration via Twilio and DeepGram.",
+    link: "https://mealsonwheels4u.com/",
+    tags: ["Food Delivery", "AI Voice", "SaaS"],
+    category: "Food & Retail",
+    gradient: "from-red-500 to-orange-500",
+  },
+  {
+    title: "ConnectWithChain",
+    description:
+      "Multi-restaurant ordering platform with pickup and delivery, pre-orders, recurring orders, Google Maps integration, Stripe payments, and AI-powered phone ordering via Twilio and spaCy.",
+    link: "https://connectwithchain.com/",
+    tags: ["Multi-Restaurant", "AI Voice", "React"],
+    category: "Food & Retail",
+    gradient: "from-pink-600 to-rose-500",
+  },
+  {
+    title: "LokBest – IoT eCommerce",
+    description:
+      "IoT-powered cashier-less in-store shopping for a German client. Customers order via mobile app and pick up in-store; entry is controlled by QR code with automated IoT access management.",
+    link: "https://www.lokbest-store.com/",
+    tags: ["IoT", "E-Commerce", "Germany"],
+    category: "E-Commerce",
+    gradient: "from-cyan-600 to-blue-500",
+  },
+  {
+    title: "LambertLauzon – Inventory",
+    description:
+      "Centralized multi-warehouse inventory management module for a Canadian furniture company — tracking stock in/out and internal transfers across multiple provincial locations.",
+    link: "https://www.lambertlauzon.com/",
+    tags: ["Inventory", "ERP", "Furniture"],
+    category: "SaaS / Enterprise",
+    gradient: "from-slate-600 to-slate-500",
+  },
+  {
+    title: "First of a Kind",
+    description:
+      "E-commerce platform with bulk CSV-based catalog management, enabling daily updates for thousands of products with images, SKUs, pricing, and inventory levels from a single spreadsheet.",
+    link: "https://firstofakind.com",
+    tags: ["E-Commerce", "Inventory", "Bulk Import"],
+    category: "E-Commerce",
+    gradient: "from-indigo-600 to-violet-500",
+  },
+];
+
+const categories = ["All", "Marketplace", "SaaS / Enterprise", "E-Commerce", "Logistics & Operations", "FinTech", "Food & Retail"];
+
 export default function Portfolio() {
+  const [activeCategory, setActiveCategory] = useState("All");
+
+  const filtered =
+    activeCategory === "All"
+      ? moreProjects
+      : moreProjects.filter((p) => p.category === activeCategory);
+
   return (
     <>
       <Navbar />
@@ -60,17 +181,21 @@ export default function Portfolio() {
               <span className="text-gradient">shipped and stood behind</span>
             </h1>
             <p className="text-xl text-slate-500 leading-relaxed">
-              A selection of client projects across insurance, construction,
-              e-learning, and real estate.
+              A selection of client projects across insurance, construction, logistics,
+              e-commerce, fintech, food delivery, IoT, and more.
             </p>
           </div>
         </div>
       </section>
 
-      {/* Projects */}
+      {/* Featured Projects */}
       <section className="py-16 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          {projects.map((project, index) => (
+          <div className="inline-flex items-center gap-2 text-slate-400 text-xs font-semibold uppercase tracking-widest mb-10">
+            <span className="w-8 h-px bg-slate-300" />
+            Featured Work
+          </div>
+          {featured.map((project, index) => (
             <motion.div
               key={index}
               initial={{ opacity: 0, y: 30 }}
@@ -121,6 +246,95 @@ export default function Portfolio() {
               </div>
             </motion.div>
           ))}
+        </div>
+      </section>
+
+      {/* More Work */}
+      <section className="py-16 bg-slate-50 border-t border-slate-100">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="mb-10">
+            <div className="inline-flex items-center gap-2 text-slate-400 text-xs font-semibold uppercase tracking-widest mb-4">
+              <span className="w-8 h-px bg-slate-300" />
+              More Work
+            </div>
+            <p className="text-slate-500 text-sm">
+              {moreProjects.length} additional projects across industries
+            </p>
+          </div>
+
+          {/* Category Filter */}
+          <div className="flex flex-wrap gap-2 mb-10">
+            {categories.map((cat) => (
+              <button
+                key={cat}
+                onClick={() => setActiveCategory(cat)}
+                className={`px-4 py-2 rounded-full text-xs font-semibold transition-all ${
+                  activeCategory === cat
+                    ? "bg-teal-600 text-white shadow-sm"
+                    : "bg-white text-slate-500 border border-slate-200 hover:border-teal-300 hover:text-teal-600"
+                }`}
+              >
+                {cat}
+              </button>
+            ))}
+          </div>
+
+          {/* Grid */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {filtered.map((project, index) => (
+              <motion.div
+                key={project.title}
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5, delay: (index % 3) * 0.1 }}
+                viewport={{ once: true }}
+                className="bg-white border border-slate-200 rounded-2xl overflow-hidden hover:shadow-lg hover:border-slate-300 transition-all duration-300 flex flex-col"
+              >
+                {/* Gradient Header */}
+                <div
+                  className={`h-28 bg-gradient-to-br ${project.gradient} flex items-end p-5`}
+                >
+                  <span className="text-white font-bold text-base leading-snug drop-shadow">
+                    {project.title}
+                  </span>
+                </div>
+
+                {/* Content */}
+                <div className="p-6 flex flex-col flex-1">
+                  <div className="flex flex-wrap gap-1.5 mb-3">
+                    {project.tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="px-2 py-0.5 rounded-md bg-slate-100 text-xs font-medium text-slate-500"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                  <p className="text-slate-500 text-sm leading-relaxed flex-1">
+                    {project.description}
+                  </p>
+                  <div className="mt-5">
+                    {project.link ? (
+                      <a
+                        href={project.link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 text-teal-600 text-xs font-semibold hover:text-teal-700 transition-colors group"
+                      >
+                        View Live Project
+                        <span className="group-hover:translate-x-0.5 transition-transform inline-block">→</span>
+                      </a>
+                    ) : (
+                      <span className="text-slate-300 text-xs font-medium">
+                        Internal / Under NDA
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </motion.div>
+            ))}
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
- Portfolio: restructure with featured section (4 projects with screenshots) + filterable 'More Work' grid (12 new projects) with category filters and gradient placeholders
- Case Studies: add TheLoadOff (ops platform), Darren (logistics MVP→SaaS), EuroTile (B2B+B2C marketplace) with full challenge/solution/results narrative