### PR TITLE
feat(analytics): install GA4 and Microsoft Clarity with full event tr…

### DIFF
--- a/src/app/case-studies/[slug]/page.jsx
+++ b/src/app/case-studies/[slug]/page.jsx
@@ -8,6 +8,7 @@ import Footer from "../../components/footer";
 import CTABanner from "../../components/cta-banner";
 import { caseStudies } from "../data";
 import { getAttribution } from "@/lib/analytics/attribution";
+import { events } from "@/lib/analytics/events";
 
 /* ─── PDF Download Modal ─────────────────────────────────────────────────── */
 
@@ -39,6 +40,10 @@ function PdfModal({ study, onClose }) {
       });
       if (!res.ok) throw new Error("Request failed");
       setDone(true);
+      events.caseStudyDownload({
+        caseStudyTitle: study.title,
+        page: `/case-studies/${study.id}`,
+      });
       // Trigger download
       const a = document.createElement("a");
       a.href = `/case-studies/${study.id}.pdf`;

--- a/src/app/components/AnalyticsScripts.jsx
+++ b/src/app/components/AnalyticsScripts.jsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Script from "next/script";
+import { analyticsConfig } from "@/lib/analytics/config";
+
+/**
+ * Injects GA4 and Microsoft Clarity scripts.
+ *
+ * Rules:
+ *  - Production only. In development/test no scripts are loaded, keeping
+ *    local traffic out of analytics and removing the need to block-list
+ *    localhost in GA4.
+ *  - One render, no conditional hooks — safe to mount unconditionally in
+ *    RootLayout.
+ *  - GA4 is initialised with send_page_view: false so NavigationEvents
+ *    controls all page view calls (avoids a double-count on first load).
+ *  - Clarity self-deduplicates via its own guard on window._clarity.
+ */
+
+const isProduction = process.env.NODE_ENV === "production";
+
+export default function AnalyticsScripts() {
+  if (!isProduction) return null;
+
+  return (
+    <>
+      {/* ── Google Analytics 4 ─────────────────────────────────────────── */}
+      {analyticsConfig.ga4.enabled && (
+        <>
+          {/* 1. Load the gtag library */}
+          <Script
+            src={`https://www.googletagmanager.com/gtag/js?id=${analyticsConfig.ga4.measurementId}`}
+            strategy="afterInteractive"
+          />
+          {/* 2. Initialise dataLayer and configure the stream */}
+          <Script
+            id="ga4-init"
+            strategy="afterInteractive"
+            dangerouslySetInnerHTML={{
+              __html: `
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                window.gtag = gtag;
+                gtag('js', new Date());
+                gtag('config', '${analyticsConfig.ga4.measurementId}', {
+                  send_page_view: false
+                });
+              `,
+            }}
+          />
+        </>
+      )}
+
+      {/* ── Microsoft Clarity ──────────────────────────────────────────── */}
+      {analyticsConfig.clarity.enabled && (
+        <Script
+          id="clarity-init"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function(c,l,a,r,i,t,y){
+                c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+                t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+                y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+              })(window,document,"clarity","script","${analyticsConfig.clarity.projectId}");
+            `,
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/components/NavigationEvents.jsx
+++ b/src/app/components/NavigationEvents.jsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { trackPageView } from "@/lib/analytics/analytics";
+
+/**
+ * Fires a page_view event on every route change, including the initial load.
+ *
+ * Next.js App Router does not expose a top-level router event the way the
+ * Pages Router did. The recommended pattern is to watch usePathname +
+ * useSearchParams — both change on every navigation.
+ *
+ * Mount once inside RootLayout (inside <body>, after AnalyticsScripts).
+ * Wrap in a Suspense boundary so useSearchParams doesn't block rendering.
+ */
+export default function NavigationEvents() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // Track whether this is the very first render so we send a page view on
+  // initial load (the ga4 script is loaded afterInteractive, so we give it
+  // a brief moment before the first call).
+  const initialRender = useRef(true);
+
+  useEffect(() => {
+    const url = pathname + (searchParams.toString() ? `?${searchParams.toString()}` : "");
+
+    if (initialRender.current) {
+      initialRender.current = false;
+      // Small delay on first load so the GA4 script has time to initialise
+      // before we push the first config call.
+      const t = setTimeout(() => trackPageView(url), 300);
+      return () => clearTimeout(t);
+    }
+
+    trackPageView(url);
+  }, [pathname, searchParams]);
+
+  return null;
+}

--- a/src/app/components/booking-cta.jsx
+++ b/src/app/components/booking-cta.jsx
@@ -1,5 +1,6 @@
 "use client";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import {
   HiCalendarDays,
   HiPhone,
@@ -10,6 +11,7 @@ import {
   HiShieldCheck,
   HiBolt,
 } from "react-icons/hi2";
+import { events } from "@/lib/analytics/events";
 
 export const BOOKING_URL = "https://calendar.app.google/tCXYTm21YtV7AkXFA";
 
@@ -34,6 +36,8 @@ export function BookingSection({
     "Honest assessment, not a sales pitch",
   ],
 }) {
+  const pathname = usePathname();
+
   return (
     <section className="relative bg-slate-900 py-24 overflow-hidden">
       {/* Background layers */}
@@ -59,6 +63,13 @@ export function BookingSection({
             href={BOOKING_URL}
             target="_blank"
             rel="noopener noreferrer"
+            onClick={() =>
+              events.bookingCtaClick({
+                label: primaryCTA,
+                destination: BOOKING_URL,
+                page: pathname,
+              })
+            }
             className="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-xl bg-gradient-to-r from-teal-600 to-blue-600 text-white font-semibold hover:opacity-90 transition-all hover:shadow-2xl hover:shadow-teal-500/30 hover:-translate-y-0.5"
           >
             <HiCalendarDays className="w-5 h-5" />
@@ -66,6 +77,12 @@ export function BookingSection({
           </a>
           <Link
             href="/contact"
+            onClick={() =>
+              events.consultationRequest({
+                label: secondaryCTA,
+                page: pathname,
+              })
+            }
             className="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-xl border border-slate-700 text-slate-300 font-semibold hover:border-slate-500 hover:text-white transition-all hover:-translate-y-0.5"
           >
             <HiPhone className="w-5 h-5" />
@@ -106,6 +123,8 @@ export function BookingBanner({
   subheading = "Get a free technical consultation from our senior engineering team.",
   cta = "Schedule Discovery Session",
 }) {
+  const pathname = usePathname();
+
   return (
     <div className="relative overflow-hidden bg-gradient-to-r from-teal-50 to-blue-50 border border-teal-200/60 rounded-2xl p-8">
       <div className="absolute top-0 right-0 w-64 h-64 bg-teal-400/10 rounded-full blur-2xl pointer-events-none" />
@@ -123,6 +142,13 @@ export function BookingBanner({
           href={BOOKING_URL}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={() =>
+            events.bookingCtaClick({
+              label: cta,
+              destination: BOOKING_URL,
+              page: pathname,
+            })
+          }
           className="flex-shrink-0 inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-gradient-to-r from-teal-600 to-blue-600 text-white font-semibold hover:opacity-90 transition-all hover:shadow-lg hover:shadow-teal-500/20 hover:-translate-y-0.5 whitespace-nowrap"
         >
           <HiCalendarDays className="w-4 h-4" />
@@ -148,6 +174,8 @@ export function BookingStrip({
     { icon: HiSparkles, label: "Top 1% Engineers" },
   ],
 }) {
+  const pathname = usePathname();
+
   return (
     <div className="bg-slate-50 border-b border-slate-200 py-3">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -164,6 +192,13 @@ export function BookingStrip({
             href={BOOKING_URL}
             target="_blank"
             rel="noopener noreferrer"
+            onClick={() =>
+              events.bookingCtaClick({
+                label: cta,
+                destination: BOOKING_URL,
+                page: pathname,
+              })
+            }
             className="flex-shrink-0 inline-flex items-center gap-1.5 text-xs font-semibold text-teal-600 hover:text-teal-700 transition-colors"
           >
             <HiCalendarDays className="w-3.5 h-3.5" />
@@ -181,11 +216,20 @@ export function BookingStrip({
    Fixed mobile button — import on "use client" pages only
 ───────────────────────────────────────────────────────────────────────────── */
 export function FloatingBookingButton({ label = "Book Call" }) {
+  const pathname = usePathname();
+
   return (
     <a
       href={BOOKING_URL}
       target="_blank"
       rel="noopener noreferrer"
+      onClick={() =>
+        events.bookingCtaClick({
+          label,
+          destination: BOOKING_URL,
+          page: pathname,
+        })
+      }
       className="fixed bottom-6 right-6 z-50 md:hidden inline-flex items-center gap-2 px-5 py-3 rounded-full bg-gradient-to-r from-teal-600 to-blue-600 text-white text-sm font-semibold shadow-2xl shadow-teal-500/40 hover:opacity-90 active:scale-95 transition-all"
     >
       <HiCalendarDays className="w-4 h-4" />

--- a/src/app/contact/page.jsx
+++ b/src/app/contact/page.jsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 import Navbar from "../components/navbar";
 import Footer from "../components/footer";
 import { getAttribution } from "@/lib/analytics/attribution";
+import { events } from "@/lib/analytics/events";
 
 const projectTypes = [
   "Web / App Development",
@@ -75,6 +76,11 @@ export default function ContactPage() {
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Something went wrong.");
       setSubmitted(true);
+      events.contactFormSubmit({
+        service: formData.projectType || undefined,
+        source: "contact_page",
+        page: "/contact",
+      });
     } catch (err) {
       setError(err.message);
     } finally {

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,7 +1,10 @@
 import { Geist } from "next/font/google";
+import { Suspense } from "react";
 import "./globals.css";
 import ISTClock from "./components/ist-clock";
 import AttributionInit from "./components/attribution-init";
+import AnalyticsScripts from "./components/AnalyticsScripts";
+import NavigationEvents from "./components/NavigationEvents";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -178,7 +181,12 @@ export default function RootLayout({ children }) {
         >
           Skip to main content
         </a>
+        <AnalyticsScripts />
         <AttributionInit />
+        {/* useSearchParams requires Suspense in App Router */}
+        <Suspense fallback={null}>
+          <NavigationEvents />
+        </Suspense>
         <ISTClock />
         <div id="main-content">{children}</div>
       </body>

--- a/src/lib/analytics/analytics.js
+++ b/src/lib/analytics/analytics.js
@@ -62,13 +62,18 @@ export function setConsent({ analytics, marketing }) {
 
 /**
  * Returns true if the user has consented to the given category.
- * Falls back to false when no decision exists yet.
+ *
+ * Pre-banner behaviour (current): returns true when no decision has been
+ * stored yet — analytics fire by default. Once the cookie banner is
+ * implemented it will call setConsent(), at which point this function
+ * will respect the stored decision. Until then, all tracking proceeds.
  *
  * @param {"analytics" | "marketing"} category
  */
 export function hasConsent(category) {
   const consent = getStoredConsent();
-  return consent ? Boolean(consent[category]) : false;
+  if (consent === null) return true; // permissive until banner is implemented
+  return Boolean(consent[category]);
 }
 
 // ─── GA4 ─────────────────────────────────────────────────────────────────────

--- a/src/lib/analytics/events.js
+++ b/src/lib/analytics/events.js
@@ -35,6 +35,7 @@ export const events = {
   },
 
   /**
+   * Primary booking CTA — opens external Google Calendar link.
    * @param {{ label?: string, destination?: string, page?: string }} props
    */
   bookingCtaClick({ label, destination, page } = {}) {
@@ -45,6 +46,19 @@ export const events = {
     if (LI_CONVERSION.BOOKING) {
       trackLinkedInConversion(LI_CONVERSION.BOOKING);
     }
+  },
+
+  /**
+   * Secondary consultation CTA — navigates to the /contact page.
+   * Distinct from bookingCtaClick so the two conversion paths are separable
+   * in GA4 reports.
+   * @param {{ label?: string, page?: string }} props
+   */
+  consultationRequest({ label, page } = {}) {
+    trackEvent({
+      name: EventName.CONSULTATION_REQUEST,
+      properties: { label, page },
+    });
   },
 
   /**

--- a/src/lib/analytics/types.js
+++ b/src/lib/analytics/types.js
@@ -8,7 +8,8 @@ export const EventName = /** @type {const} */ ({
 
   // ─── Lead / conversion ────────────────────────────────────────────────────
   CONTACT_FORM_SUBMIT: "contact_form_submit",
-  BOOKING_CTA_CLICK: "booking_cta_click",
+  BOOKING_CTA_CLICK: "booking_cta_click",      // opens external calendar
+  CONSULTATION_REQUEST: "consultation_request", // navigates to /contact page
   CASE_STUDY_DOWNLOAD: "case_study_download",
 
   // ─── Engagement ───────────────────────────────────────────────────────────


### PR DESCRIPTION
…acking

Activates the analytics foundation layer with real provider scripts and wires event tracking into every conversion touchpoint on the site.

Script loading (AnalyticsScripts.jsx):
- GA4 (G-17QXEHXX0Y): gtag.js loaded afterInteractive + init with send_page_view:false so NavigationEvents owns all page view calls
- Clarity (wyl5x7g27v): inline snippet loaded afterInteractive
- Both scripts are production-only — local traffic never hits analytics
- Guards against double-init via Next.js Script id deduplication

Route tracking (NavigationEvents.jsx):
- Watches usePathname + useSearchParams (App Router pattern)
- Fires page_view on initial mount (300ms delay to let gtag init) and on every subsequent navigation
- Wrapped in Suspense in RootLayout as required by useSearchParams

Event tracking integrated at every conversion point:
- contact_form_submit → contact form on POST success (includes projectType)
- case_study_download → PDF modal on POST success (includes case study title)
- booking_cta_click → all four BookingCTA variants (Section/Banner/Strip/Float)
- consultation_request → "Talk to Our Experts" secondary CTA (new event, distinct from booking_cta_click so the two conversion paths are separable)

Analytics layer fixes:
- hasConsent() now returns true when no decision exists (permissive default pre-banner). Previously returned false, silently dropping all events. When the cookie consent banner is built it will call setConsent() and this function will respect the stored decision from that point on.
- Added CONSULTATION_REQUEST to EventName constants in types.js
- Added consultationRequest() helper to events.js

Build: 112 pages, 0 errors. Both IDs confirmed in layout bundle.